### PR TITLE
Drop haskell from asdf managed family

### DIFF
--- a/.config/.tool-versions
+++ b/.config/.tool-versions
@@ -9,5 +9,4 @@ shellcheck 0.8.0
 shfmt 3.5.1
 cargo-make 0.36.3
 just 1.8.0
-haskell 9.4.3
 bun 0.2.2


### PR DESCRIPTION
https://github.com/kachick/asdf-haskell/pull/1

It actually do not work in github runner and some ubuntu distributions now 🤔 

Means to test of https://github.com/kachick/public_dotfiles/commit/3a4ee69aef3d795e21b4622096220759741db22a