### PR TITLE
Prefer macos-13 GHA runner over macos-15 by introducing cachix

### DIFF
--- a/.github/workflows/ci-home.yml
+++ b/.github/workflows/ci-home.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-24.04
-          - macos-15
+          - macos-13 # Don't use macos-14 or later. macos-13 is the last runner of x86_64-darwin
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: DeterminateSystems/nix-installer-action@v19
@@ -55,8 +55,6 @@ jobs:
         with:
           name: kachick-dotfiles
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-          # I only have Intel Mac. See 'github-actions@macos-*' in flake.nix for the background
-          skipPush: ${{ runner.os == 'macOS' && runner.arch != 'x86_64' }}
 
       # https://www.reddit.com/r/Nix/comments/1443k3o/comment/jr9ht5g/?utm_source=reddit&utm_medium=web2x&context=3
       - run: mkdir -p ~/.local/state/nix/profiles

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -27,13 +27,8 @@ permissions:
 
 jobs:
   inspect:
-    strategy:
-      fail-fast: false
-      matrix:
-        runner:
-          - ubuntu-24.04
-          - macos-15
-    runs-on: ${{ matrix.runner }}
+    # Only on Linux is enough to check the flake
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -54,8 +49,6 @@ jobs:
           # Required to clarify allowing unfree even in check ... :<
           # This does not make problem only here, because this step does not upload any artifacts.
           NIXPKGS_ALLOW_UNFREE: '1'
-        # https://github.com/kachick/dotfiles/pull/718#issuecomment-2266331003
-        if: runner.os == 'Linux'
 
   tasks:
     defaults:
@@ -66,7 +59,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-24.04
-          - macos-15
+          - macos-13 # Don't use macos-14 or later. macos-13 is the last runner of x86_64-darwin
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     steps:
@@ -74,6 +67,13 @@ jobs:
         with:
           persist-credentials: false
       - uses: DeterminateSystems/nix-installer-action@v19
+        with:
+          extra-conf: |
+            accept-flake-config = true
+      - uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
+        with:
+          name: kachick-dotfiles
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Measure nix shell initialization time
         run: echo 'This step should be done before any other "nix develop" steps'
       - run: task ci-dev

--- a/flake.nix
+++ b/flake.nix
@@ -223,14 +223,10 @@
             ];
           };
 
-          # macos-13 is the latest x86-64 runner for darwin and technically the right choice for respecting architecture of my old MacBook,
-          # but it's slow, almost 3x slower than Linux runners - so I prefer macos-14 or later. :<
-          #
-          # From another angle, I do keep my MacBook OS up-to-date, so maybe it's actually more appropriate as a CI environment than macos-13.
-          # Ideally, I guess it would be best to run both macos-13 and "macos-latest or later"(actually not "latest" in GitHub!),
-          # but I spend less than 1% of my time on macOS compared to Linux, so I don't want to make things more complex here.
-          "github-actions@macos-15" = home-manager-darwin.lib.homeManagerConfiguration {
-            pkgs = mkPkgs "aarch64-darwin";
+          # macos-13 is the latest x86_64-darwin runner for darwin and technically the right choice for respecting architecture of my old MacBook,
+          # but it's slow, almost 3x slower than Linux runners. So you should use binary cache if use this runner
+          "github-actions@macos-13" = home-manager-darwin.lib.homeManagerConfiguration {
+            pkgs = mkPkgs "x86_64-darwin";
             # Prefer "kachick" over "common" only here.
             # Using values as much as possible as actual values to create a robust CI
             modules = [


### PR DESCRIPTION
After GH-1235(GH-754), I may use the much slow macos-13 runner again if enabling the binary cache for darwin.

Partially revert GH-1165(GH-1164)
Might related to GH-1167, GH-1198, GH-911
