### PR TITLE
Restore Avahi except mDNS to fix printer discovery

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -179,7 +179,9 @@
     # I prefer systemd-resolved for mDNS use, because of enabling on Avahi makes much flaky resolutions
     # You can test it with: `avahi-resolve-host-name hostname.local` if enabled
 
-    nssmdns = false;
+    # Ensure disabling them even through disabled by NixOS default. Ensure avoiding conflict with systemd-resolved
+    nssmdns4 = false;
+    nssmdns6 = false;
   };
 
   ## systemd-resolved (Modern, not supported by CUPS)


### PR DESCRIPTION
GH-938 is now regression, appears since around GH-1266
