### PR TITLE
linux-firmware: 20251021 -> 20251011 to fix flaky iwlwifi

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -17,8 +17,23 @@
     };
   })
 
-  # Patched and override existing name because of it is not cofigurable
+  # Patched and override existing name because of it is not configurable
   (final: prev: {
+    # https://github.com/NixOS/nixpkgs/blob/nixos-25.05/pkgs/by-name/li/linux-firmware/package.nix
+    linux-firmware = prev.linux-firmware.overrideAttrs (
+      finalAttrs: previousAttrs: rec {
+        # Don't use "20251021" and the later versions for now. See GH-1328 for detail
+        version = "20251011";
+
+        src = prev.fetchFromGitLab {
+          owner = "kernel-firmware";
+          repo = "linux-firmware";
+          tag = version;
+          hash = "sha256-LFVrrVCqJORiHVnhIY0l7B4pRHI2MS0o/GbgOUDqO8s=";
+        };
+      }
+    );
+
     # TODO: Use `services.gnome.gcr-ssh-agent.enable = false` since nixos-25.11
     #
     # https://github.com/NixOS/nixpkgs/blob/nixos-25.05/pkgs/by-name/gn/gnome-keyring/package.nix


### PR DESCRIPTION
Revert https://github.com/NixOS/nixpkgs/commit/846475fdddf617ba9b5ae256bd2e8608d0b42a91 in this repository
To exclude https://gitlab.com/kernel-firmware/linux-firmware/-/compare/20251011...20251021
It seems having some iwlwifi commits

https://gitlab.com/kernel-firmware/linux-firmware/-/commit/822db3708dbca682fe37e97c108d5cba9b40d02e
https://gitlab.com/kernel-firmware/linux-firmware/-/commit/dda8b9b09a1c4720e8356b0f80daa5dce9efe360
https://gitlab.com/kernel-firmware/linux-firmware/-/commit/f2fbfd22d9d1201133353989107997efec84ed7f
https://gitlab.com/kernel-firmware/linux-firmware/-/commit/9440754a997a128d04af13c377f289ed75068193

Fixes GH-1328
