### PR TITLE
Free-up GHA disk space in ci-home workflow

### DIFF
--- a/.github/workflows/ci-home.yml
+++ b/.github/workflows/ci-home.yml
@@ -39,6 +39,23 @@ jobs:
           - macos-15-intel
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Logging disk space
+        run: df -h
+      # Prevent problems such as https://github.com/kachick/dotfiles/pull/1402#issuecomment-3736925185
+      - name: Clean disk space as per https://github.com/actions/virtual-environments/issues/709
+        # NOTE: This workflow removed 14 Gib in 50sec
+        # On the otherhand, additional apt purge step removed 6 Gib in 100s, so I don't want to use the additional steps for now
+        run: |
+          docker image prune --all --force
+          sudo rm -rf '/opt/ghc' \
+            '/usr/share/dotnet' \
+            "$AGENT_TOOLSDIRECTORY" \
+             '/usr/local/lib/android' \
+             '/usr/local/share/boost'
+        # I didn't face any disk problem on darwin runner yet
+        if: runner.os == 'Linux'
+      - name: Logging disk space after clean
+        run: df -h
       - uses: actions/checkout@v6.0.1
         with:
           persist-credentials: false


### PR DESCRIPTION
Prevent problems such as https://github.com/kachick/dotfiles/pull/1402#issuecomment-3736925185i

This step may take 1-5 minutes, it might be much frustrated on daily use :<
