### PR TITLE
Enable fstrim for LUKS on SSD

### DIFF
--- a/nixos/hosts/algae/default.nix
+++ b/nixos/hosts/algae/default.nix
@@ -26,7 +26,12 @@
 
   # https://github.com/NixOS/nixpkgs/blob/nixos-25.11/nixos/modules/system/boot/luksroot.nix
   boot.initrd.luks.devices."luks-9b94a10b-7ca3-4e4f-b52d-b1cf5104b519" = {
+    # fstrim is enabled by default for each week:
+    # https://github.com/NixOS/nixpkgs/blob/35b4600dfe916d64506ad6dfad275faeca833a6f/nixos/modules/services/misc/fstrim.nix#L16-L22
+    # See also the result of "Size/Capacity" and "Utilization": `sudo smartctl -a /dev/nvme0n1`
+    # If you want to run fstrim immediately: `sudo fstrim -av`
     allowDiscards = true;
+
     bypassWorkqueues = true;
   };
 

--- a/nixos/hosts/algae/default.nix
+++ b/nixos/hosts/algae/default.nix
@@ -24,6 +24,12 @@
   # https://github.com/NixOS/nixpkgs/issues/219239
   boot.initrd.kernelModules = [ "amdgpu" ];
 
+  # https://github.com/NixOS/nixpkgs/blob/nixos-25.11/nixos/modules/system/boot/luksroot.nix
+  boot.initrd.luks.devices."luks-9b94a10b-7ca3-4e4f-b52d-b1cf5104b519" = {
+    allowDiscards = true;
+    bypassWorkqueues = true;
+  };
+
   boot.loader.systemd-boot = {
     enable = true;
     configurationLimit = 20;

--- a/nixos/hosts/algae/default.nix
+++ b/nixos/hosts/algae/default.nix
@@ -26,11 +26,11 @@
 
   # https://github.com/NixOS/nixpkgs/blob/nixos-25.11/nixos/modules/system/boot/luksroot.nix
   boot.initrd.luks.devices."luks-9b94a10b-7ca3-4e4f-b52d-b1cf5104b519" = {
-    # fstrim is enabled by default for each week:
+    # fstrim is enabled weekly by default:
     # https://github.com/NixOS/nixpkgs/blob/35b4600dfe916d64506ad6dfad275faeca833a6f/nixos/modules/services/misc/fstrim.nix#L16-L22
-    # See also the result of "Size/Capacity" and "Utilization": `sudo smartctl -a /dev/nvme0n1`
-    # If you want to run fstrim immediately: `sudo fstrim -av`
-    allowDiscards = true;
+    # Check "Size/Capacity" and "Utilization" via: sudo smartctl -a /dev/nvme0n1
+    # To run fstrim immediately: sudo fstrim -av
+    allowDiscards = true; # See GH-1555 for the background
 
     bypassWorkqueues = true;
   };


### PR DESCRIPTION
Attempt to fix GH-1255

---

I noticed currently enables luks on algae and none on moss. And this performance issue only happened on the algae.

dysk returns 691G/980GiB used, but smartctl returns 997 GB/1.00 TB used.
Even through having trade-off problems, I should use fstrim on the LUKS at least for 1TiB SSD.

Enabling this option and run `fstrim -av` manually. It appears resolved on the stats.

```console
> sudo fstrim -av
/boot: /dev/nvme0n1p1 で 846.2 MiB (887267328 バイト) trim されました
/dev/mapper/luks-9b94a10b-7ca3-4e4f-b52d-b1cf5104b519 で 315.5 GiB (338775830528 バイト) trim されました
```
