### PR TITLE
Add ibus-engine-selector for quick layout switching

### DIFF
--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -148,6 +148,7 @@ in
     packages = with pkgs; [
       kanata # Don't require kanata-with-cmd for now
       pinned.kanata-tray
+      local.ibus-engine-selector
     ];
 
     sessionVariables = {

--- a/pkgs/local/ibus-engine-selector/main.go
+++ b/pkgs/local/ibus-engine-selector/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func main() {
+	configPath := os.Getenv("IBUS_CONFIG_TEXTPROTO")
+	if configPath == "" {
+		log.Fatal("IBUS_CONFIG_TEXTPROTO is not set. Please provide it via environment variable or use a version built with Nix.")
+	}
+
+	f, err := os.Open(configPath)
+	if err != nil {
+		log.Fatalf("Error opening config (%s): %v", configPath, err)
+	}
+	defer f.Close()
+
+	engines, err := parseConfig(f)
+	if err != nil {
+		log.Fatalf("Error parsing config: %v", err)
+	}
+
+	var options []string
+	for _, e := range engines {
+		options = append(options, fmt.Sprintf("%-20s # Mozc (%s)", e.name, e.longname))
+	}
+	options = append(options, "xkb:us::eng           # Typically disable Mozc (ANSI)")
+	options = append(options, "xkb:us::jpn           # Typically disable Mozc (JIS)")
+
+	selected, err := runFzf(options)
+	if err != nil {
+		// fzf returns 130 when cancelled with Esc/Ctrl-C
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 130 {
+			os.Exit(0)
+		}
+		log.Fatalf("Error running fzf: %v", err)
+	}
+
+	engineName := strings.Fields(selected)[0]
+	fmt.Printf("Switching to %s...\n", engineName)
+	if err := runIbus(engineName); err != nil {
+		log.Fatalf("Error running ibus: %v", err)
+	}
+}
+
+func parseConfig(r io.Reader) ([]engine, error) {
+	var engines []engine
+	var current engine
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if strings.HasPrefix(line, "name :") {
+			current.name = strings.Trim(strings.Split(line, ":")[1], " \"")
+		}
+		if strings.HasPrefix(line, "longname :") {
+			current.longname = strings.Trim(strings.Split(line, ":")[1], " \"")
+		}
+		if line == "}" && current.name != "" {
+			engines = append(engines, current)
+			current = engine{}
+		}
+	}
+	return engines, scanner.Err()
+}
+
+type engine struct {
+	name     string
+	longname string
+}
+
+func runFzf(options []string) (string, error) {
+	cmd := exec.Command("fzf", "--prompt=Select iBus engine: ", "--height=40%", "--reverse", "--ansi")
+	cmd.Stdin = strings.NewReader(strings.Join(options, "\n"))
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func runIbus(engine string) error {
+	return exec.Command("ibus", "engine", engine).Run()
+}

--- a/pkgs/local/ibus-engine-selector/main_test.go
+++ b/pkgs/local/ibus-engine-selector/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseConfig(t *testing.T) {
+	input := `
+engines {
+  name : "mozc-jp-ansi"
+  longname : "ANSI"
+}
+engines {
+  name : "mozc-jp-jis"
+  longname : "JIS"
+}
+# Below engines are defined by default
+engines {
+  name : "mozc-jp"
+  longname : "Mozc"
+}
+`
+	engines, err := parseConfig(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("parseConfig failed: %v", err)
+	}
+
+	// Should extract ALL engines now
+	if len(engines) != 3 {
+		t.Errorf("expected 3 engines, got %d", len(engines))
+	}
+
+	expected := []struct {
+		name     string
+		longname string
+	}{
+		{"mozc-jp-ansi", "ANSI"},
+		{"mozc-jp-jis", "JIS"},
+		{"mozc-jp", "Mozc"},
+	}
+
+	for i, exp := range expected {
+		if engines[i].name != exp.name || engines[i].longname != exp.longname {
+			t.Errorf("engine %d: expected %+v, got %+v", i, exp, engines[i])
+		}
+	}
+}

--- a/pkgs/local/ibus-engine-selector/package.nix
+++ b/pkgs/local/ibus-engine-selector/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  pkgs,
+  makeWrapper,
+  fzf,
+  ibus,
+  ...
+}:
+
+let
+  configPath = ../../../config/mozc/ibus_config.textproto;
+  inherit (pkgs.unstable) buildGo126Module;
+in
+buildGo126Module (finalAttrs: {
+  pname = "ibus-engine-selector";
+  version = "0.1.0";
+
+  src =
+    with lib.fileset;
+    toSource {
+      root = ../../../.;
+      fileset = unions [
+        ../../../go.mod
+        ../../../go.sum
+        ./.
+      ];
+    };
+
+  vendorHash = "sha256-KgAbEW9xMz4ag6SDqKlrpRMaE4OowUr6mgx/0Lnnd28=";
+
+  subPackages = [ "pkgs/local/${finalAttrs.pname}" ];
+
+  ldflags = [ "-s" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/ibus-engine-selector \
+      --set-default IBUS_CONFIG_TEXTPROTO ${configPath} \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          fzf
+          ibus
+        ]
+      }
+  '';
+
+  passthru.shared-gomod = true;
+
+  meta = {
+    description = "Select IBus engine with fzf";
+    longDescription = ''
+      This tool is provided because Mozc's configuration management is limited.
+      Especially keyboard layout settings (like ANSI vs JIS) are not automatically loaded from the config file via CLI or standard rc files.
+      Usually, one needs to import/configure them via GUI (mozc_tool) and then run `ibus write-cache; ibus restart`.
+      This process is extremely tedious in environments like LiveCDs or during fresh installations where quick setup is preferred.
+    '';
+    license = lib.licenses.mit;
+    mainProgram = finalAttrs.pname;
+  };
+})

--- a/pkgs/local/ibus-engine-selector/package.nix
+++ b/pkgs/local/ibus-engine-selector/package.nix
@@ -26,7 +26,7 @@ buildGo126Module (finalAttrs: {
       ];
     };
 
-  vendorHash = "sha256-KgAbEW9xMz4ag6SDqKlrpRMaE4OowUr6mgx/0Lnnd28=";
+  vendorHash = "sha256-tvq951p9pznSyLeQDYHbo4PvXLR0VrgUXR2j4AW5Ir0=";
 
   subPackages = [ "pkgs/local/${finalAttrs.pname}" ];
 


### PR DESCRIPTION
Mozc configuration is hard to manage via dotfiles because it lacks CLI
tools and standard rc file support for layout settings. Switching
between ANSI and JIS layouts typically requires manual GUI interaction
and service restarts, which is tedious in temporary environments like
LiveCDs.

This new tool extracts engine definitions from the local Mozc config and
provides an fzf interface to quickly switch IBus engines, including
fallback XKB layouts to disable Mozc.
