### PR TITLE
Package IBM Plex fonts individually to save space and up-to-date

### DIFF
--- a/.github/workflows/package-darwin.yml
+++ b/.github/workflows/package-darwin.yml
@@ -43,6 +43,9 @@ jobs:
       # kanata-tray: I'm using Karabiner-Elements on macOS, so exclude it here.
       TARGET_PACKAGES: >-
         lima-full
+        ibm-plex-sans-jp
+        ibm-plex-mono
+        ibm-plex-serif-variable
     outputs:
       packages: ${{ steps.set-matrix.outputs.packages }}
     steps:

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -53,6 +53,9 @@ jobs:
             "mozc"
             "yaneuraou-avx2"
             "hcpu_shogi"
+            "ibm-plex-sans-jp"
+            "ibm-plex-mono"
+            "ibm-plex-serif-variable"
           )
 
           # Dynamically add all shared-gomod packages

--- a/home-manager/darwin.nix
+++ b/home-manager/darwin.nix
@@ -44,8 +44,10 @@
 
       # You can also use 0 = `Slashed zero style` with enabling `"editor.fontLigatures": "'zero'"` in vscode
       # but cannot use it in alacritty https://github.com/alacritty/alacritty/issues/50
-      plemoljp-nf
-      ibm-plex # For sans-serif, use plemoljp for developing
+      plemoljp-nf # For developing
+      local.ibm-plex-sans-jp
+      local.ibm-plex-mono
+      local.ibm-plex-serif-variable
     ];
   };
 

--- a/nixos/desktop/font.nix
+++ b/nixos/desktop/font.nix
@@ -16,7 +16,9 @@
       # While the Source Han series offers even more extensive fallback definitions,
       # adding them all leads to significant disk bloat.
       # Thus, I've opted for IBM Plex as the primary set and omitted most Source Han variants.
-      ibm-plex
+      local.ibm-plex-sans-jp
+      local.ibm-plex-mono
+      local.ibm-plex-serif-variable
       plemoljp-nf
 
       # emoji
@@ -39,13 +41,12 @@
       # Without it often made troubles, such as chrome bookmarkbar uses monochrome emojis
       defaultFonts = {
         serif = [
-          "IBM Plex Serif"
+          "IBM Plex Serif Var"
           "Source Han Sans" # Fallback to Sans if Serif not found
           "Noto Color Emoji"
         ];
         sansSerif = [
           "IBM Plex Sans JP"
-          "IBM Plex Sans"
           "Source Han Sans"
           "Noto Color Emoji"
         ];

--- a/overlays/unstable.nix
+++ b/overlays/unstable.nix
@@ -6,6 +6,8 @@ nixpkgs-unstable: final: _prev: {
     inherit (final.stdenvNoCC.hostPlatform) system;
   };
 
+  inherit (final.unstable) installFonts;
+
   /*
     unstable =
       let

--- a/pkgs/local/ibm-plex-mono/package.nix
+++ b/pkgs/local/ibm-plex-mono/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  installFonts,
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "ibm-plex-mono";
+  version = "1.1.0";
+
+  # REVISIT: https://github.com/NixOS/nixpkgs/pull/505549
+  # As of 2026-04-22, the upstream PR combines all IBM Plex fonts into a single package,
+  # which leads to unnecessary disk bloat. We use individual packages here to minimize the footprint.
+  src = fetchzip {
+    url = "https://github.com/IBM/plex/releases/download/@ibm/plex-mono@${version}/ibm-plex-mono.zip";
+    hash = "sha256-OwUmrPfEehLDz0fl2ChYLK8FQM2p0G1+EMrGsYEq+6g=";
+    stripRoot = true;
+  };
+
+  nativeBuildInputs = [ installFonts ];
+
+  meta = {
+    description = "IBM Plex Mono";
+    homepage = "https://github.com/IBM/plex";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/local/ibm-plex-sans-jp/package.nix
+++ b/pkgs/local/ibm-plex-sans-jp/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  installFonts,
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "ibm-plex-sans-jp";
+  version = "3.0.0";
+
+  # REVISIT: https://github.com/NixOS/nixpkgs/pull/505549
+  # As of 2026-04-22, the upstream PR combines all IBM Plex fonts into a single package,
+  # which leads to unnecessary disk bloat. We use individual packages here to minimize the footprint.
+  src = fetchzip {
+    url = "https://github.com/IBM/plex/releases/download/@ibm/plex-sans-jp@${version}/ibm-plex-sans-jp.zip";
+    hash = "sha256-2BbhqsutMXEoS2JoZjJprrElIpFa9lgvPaM65pnYdfs=";
+    stripRoot = true;
+  };
+
+  # Pick otf hinted as source root to avoid collisions with unhinted and ttf variants
+  sourceRoot = "source/fonts/complete/otf/hinted";
+
+  nativeBuildInputs = [ installFonts ];
+
+  meta = {
+    description = "IBM Plex Sans JP";
+    homepage = "https://github.com/IBM/plex";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/local/ibm-plex-serif-variable/package.nix
+++ b/pkgs/local/ibm-plex-serif-variable/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  installFonts,
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "ibm-plex-serif-variable";
+  version = "2.0.0";
+
+  # REVISIT: https://github.com/NixOS/nixpkgs/pull/505549
+  # As of 2026-04-22, the upstream PR combines all IBM Plex fonts into a single package,
+  # which leads to unnecessary disk bloat. We use individual packages here to minimize the footprint.
+  src = fetchzip {
+    url = "https://github.com/IBM/plex/releases/download/@ibm/plex-serif-variable@${version}/plex-serif-variable.zip";
+    hash = "sha256-xhjmeIMT7FAFhfR8fekAxzQEl1hOtPdQ6qsVpnZN6Xg=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [ installFonts ];
+
+  meta = {
+    description = "IBM Plex Serif Variable";
+    homepage = "https://github.com/IBM/plex";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
IBM Plex v1.1.0 in nixpkgs is monolithic and outdated.
While a nixpkgs update PR
is in progress, it still combines all families into one package.

This change introduces individual packages for Sans JP (v3.0.0),
Mono (v1.1.0), and Serif Variable (v2.0.0) in to reduce
disk footprint. Total size reduced from ~123MB to ~38MB.
