### PR TITLE
Update and pin the Visual Studio version in Windows runner

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-24.04
-          - windows-2025
+          - windows-2025-vs2026
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,7 @@ defaults:
 
 jobs:
   inspect_runner:
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     steps:
       - name: Print some variables that were applied in GH-617
         run: |
@@ -50,7 +50,7 @@ jobs:
   #
   # Not Terraform :)
   terraform:
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     steps:
       - name: Prepare Windows Defender
         # https://github.com/actions/runner-images/issues/855#issuecomment-626692949 may help to understand


### PR DESCRIPTION
https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners
