### PR TITLE
Follow-up nixos 26.05 changes in CI/CD

### DIFF
--- a/.github/workflows/ci-nixos.yml
+++ b/.github/workflows/ci-nixos.yml
@@ -68,6 +68,21 @@ jobs:
       matrix:
         host: [desktop-free, wsl]
     steps:
+      - name: Logging disk space
+        run: df -h
+      # Prevent problems such as https://github.com/kachick/dotfiles/pull/1402#issuecomment-3736925185
+      - name: Clean disk space as per https://github.com/actions/virtual-environments/issues/709
+        # NOTE: This workflow removed 14 Gib in 50sec
+        # On the otherhand, additional apt purge step removed 6 Gib in 100s, so I don't want to use the additional steps for now
+        run: |
+          docker image prune --all --force
+          sudo rm -rf '/opt/ghc' \
+            '/usr/share/dotnet' \
+            "$AGENT_TOOLSDIRECTORY" \
+             '/usr/local/lib/android' \
+             '/usr/local/share/boost'
+      - name: Logging disk space after clean
+        run: df -h
       - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false

--- a/nixos/hosts/installer/default.nix
+++ b/nixos/hosts/installer/default.nix
@@ -58,4 +58,8 @@ in
   };
 
   system.stateVersion = "26.05";
+
+  # Disable to avoid SC2174 for `mkdir -m 0700 -p /root/.nix-defexpr`
+  # Revisit once using 26.11 or later
+  systemd.enableStrictShellChecks = lib.mkForce false;
 }


### PR DESCRIPTION
- **Disbable systemd.enableStrictShellChecks when using cd-dvd module**
- **Clean disk space when building desktop-free NixOS on GHA**

Follow-up: https://github.com/kachick/dotfiles/pull/1587
To fix

- https://github.com/kachick/dotfiles/actions/runs/26675133795/job/78625375438
- https://github.com/kachick/dotfiles/actions/runs/26672127827
