### PR TITLE
Replace macos-15-intel with macos-26-intel

### DIFF
--- a/.github/workflows/ci-home-darwin.yml
+++ b/.github/workflows/ci-home-darwin.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
           # Use a common script to check if the home-manager configuration needs a rebuild.
-          if ! ./scripts/check-nix-cache.bash '.#homeConfigurations."github-actions@macos-15-intel".activationPackage'; then
+          if ! ./scripts/check-nix-cache.bash '.#homeConfigurations."github-actions@macos-26-intel".activationPackage'; then
             echo "Home manager configuration needs a rebuild. Running on Darwin."
             echo "should_run=true" >> $GITHUB_OUTPUT
           else
@@ -88,10 +88,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-15-intel is the last x86_64-darwin runner. It is very slow, but we must use it.
+        # macos-26-intel is the last x86_64-darwin runner. It is very slow, but we must use it.
         # See darwin/README.md for the reason why we don't use ARM runners for cross-builds.
         runner:
-          - macos-15-intel
+          - macos-26-intel
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/nix-diff.yml
+++ b/.github/workflows/nix-diff.yml
@@ -28,7 +28,7 @@ jobs:
           - target: home-manager-darwin
             # Use macos-26 (ARM) for faster evaluation of x86_64-darwin configurations.
             # While this may trigger Rosetta 2 for IFD builds, the overall evaluation
-            # speed is expected to be superior to the old macos-15-intel runner.
+            # speed is expected to be superior to the old macos-26-intel runner.
             runner: macos-26
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60

--- a/.github/workflows/package-darwin.yml
+++ b/.github/workflows/package-darwin.yml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [macos-15-intel]
+        runner: [macos-26-intel]
         pname: ${{ fromJSON(needs.planning.outputs.packages) }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 180

--- a/darwin/README.md
+++ b/darwin/README.md
@@ -6,7 +6,7 @@ Extracted to [wiki](https://github.com/kachick/dotfiles/wiki/macOS)
 
 As of early 2026, this repository prioritizes Linux, and macOS (Darwin) maintenance is on a "best-effort" basis due to high CI costs and low usage (less than 10%).
 
-- **CI Strategy**: We use the slow `macos-15-intel` runners for Darwin.
+- **CI Strategy**: We use the slow `macos-26-intel` runners for Darwin.
 - **Experimental Failure**: We attempted to use fast ARM runners (`macos-26`) with Rosetta 2 emulation to build/test Intel binaries to reduce CI costs. However, it was not adopted for the following reasons:
   - **Performance**: Emulation was significantly slower than native Intel runners. For example, building the `lima` package took about 26 minutes, compared to 14 minutes on a native Intel runner.
   - **Compatibility**: Some tools and tests (e.g., `lima`) detect the host architecture and fail when running under Rosetta 2.

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -79,7 +79,7 @@ in
     }
   );
 
-  "github-actions@macos-15-intel" = home-manager-darwin.lib.homeManagerConfiguration (
+  "github-actions@macos-26-intel" = home-manager-darwin.lib.homeManagerConfiguration (
     shared
     // {
       pkgs = mkPkgs "x86_64-darwin";

--- a/pkgs/local/lima/package.nix
+++ b/pkgs/local/lima/package.nix
@@ -8,7 +8,7 @@
   darwin,
   xorriso,
   makeWrapper,
-  apple-sdk_15, # Use 15 over 26 to consider GHA. macos-15-intel is the last x86_64-darwin runner for GitHub Actions.
+  apple-sdk_26,
   writableTmpDirAsHomeHook,
   versionCheckHook,
   testers,
@@ -46,7 +46,7 @@ buildGo126Module (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.sigtool ];
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_15 ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_26 ];
 
   postPatch = ''
     substituteInPlace Makefile \

--- a/pkgs/local/nix-diff/main.go
+++ b/pkgs/local/nix-diff/main.go
@@ -30,7 +30,7 @@ func main() {
 		{Name: "DevShell", Attribute: "devShells.x86_64-linux.default"},
 		{Name: "NixOS", Attribute: "nixosConfigurations.algae.config.system.build.toplevel"},
 		{Name: "home-manager-linux", Attribute: `homeConfigurations."github-actions@ubuntu-24.04".activationPackage`},
-		{Name: "home-manager-darwin", Attribute: `homeConfigurations."github-actions@macos-15-intel".activationPackage`},
+		{Name: "home-manager-darwin", Attribute: `homeConfigurations."github-actions@macos-26-intel".activationPackage`},
 	}
 
 	var targets []Target


### PR DESCRIPTION
ref: https://github.com/kachick/dotfiles/issues/1198

I didn't know macos-26-intel is available in public repositories.
But I may stop merging this PR, because Apple actually supports my old device with macos-15.