### PR TITLE
Replace uutils.coreutils with Microsoft.Coreutils in Windows

### DIFF
--- a/windows/winget/winget-pkgs-basic.json
+++ b/windows/winget/winget-pkgs-basic.json
@@ -56,7 +56,7 @@
           "PackageIdentifier": "zyedidia.micro"
         },
         {
-          "PackageIdentifier": "uutils.coreutils"
+          "PackageIdentifier": "Microsoft.Coreutils"
         },
         {
           "PackageIdentifier": "WerWolv.ImHex"

--- a/windows/winget/winget-pkgs-ci.json
+++ b/windows/winget/winget-pkgs-ci.json
@@ -5,6 +5,9 @@
     {
       "Packages": [
         {
+          "PackageIdentifier": "Microsoft.Coreutils"
+        },
+        {
           "PackageIdentifier": "Starship.Starship"
         },
         {


### PR DESCRIPTION
Follow https://blogs.windows.com/windowsdeveloper/2026/06/02/build-2026-furthering-windows-as-the-trusted-platform-for-development/
Repo: https://github.com/microsoft/coreutils
winget: `https://github.com/microsoft/winget-pkgs/pull/382487`

It also includes findutils and grep, but this repo isn't using them in Windows.
