### PR TITLE
Introduce dprint-plugin-dockerfile

### DIFF
--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -19,4 +19,4 @@ COPY ./containers/needs_systemd.bash /provisioner/needs_systemd.bash
 
 # Should back to original of kachick/ubuntu-nix-systemd, we need to run systemd first
 USER root
-CMD [ "/bin/systemd", "--system" ]
+CMD ["/bin/systemd", "--system"]

--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -25,6 +25,7 @@
     "https://plugins.dprint.dev/markdown-0.22.1.wasm",
     "https://plugins.dprint.dev/toml-0.7.0.wasm",
     "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
-    "https://plugins.dprint.dev/kachick/kdl-0.2.1.wasm"
+    "https://plugins.dprint.dev/kachick/kdl-0.2.1.wasm",
+    "https://plugins.dprint.dev/dockerfile-0.4.1.wasm"
   ]
 }

--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -11,6 +11,11 @@
   },
   "toml": {
   },
+  "dockerfile": {
+    "associations": [
+      "Containerfile"
+    ]
+  },
   // Revisit once dprint supports fully gitignore: https://github.com/dprint/dprint/issues/1012
   "excludes": [
     ".git",


### PR DESCRIPTION
- **`dprint add dockerfile`**
- **Use dprint-plugin-dockerfile for Containerfile**
- **`dprint fmt`**

Because `https://github.com/dprint/dprint-plugin-dockerfile/issues/7` has resolved in 0.4.0