### PR TITLE
Drop incremental container builds

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -14,11 +14,6 @@ on:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     - cron: '42 14 * * *'
   workflow_dispatch:
-    inputs:
-      force_full_rebuild:
-        description: 'Force a full rebuild from the clean base image'
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -122,31 +117,6 @@ jobs:
       - uses: actions/checkout@v6.0.3
         with:
           persist-credentials: false
-      - name: Determine base image
-        id: base
-        run: |
-          # The latest provisioned image
-          PREV_IMAGE="${{ env.GHCR_BASE }}/${{ env.IMAGE_NAME }}:latest"
-
-          # Conditions for full rebuild
-          # 1. Manual trigger with force_full_rebuild: true
-          # 2. Scheduled run on even weeks (2-week cycle)
-          FORCE_FULL="${{ github.event.inputs.force_full_rebuild }}"
-          if [[ "${{ github.event_name }}" == "schedule" ]] && [[ $(( (10#$(date +%V)) % 2 )) -eq 0 ]]; then
-            FORCE_FULL="true"
-          fi
-
-          if [[ "$FORCE_FULL" != "true" ]]; then
-            # Check if the previous image exists on GHCR
-            # GitHub token can pull the image from GHCR
-            if podman pull "$PREV_IMAGE"; then
-              echo "BASE_IMAGE=${PREV_IMAGE}" | tee -a "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
-
-          # Fallback to empty string, let Containerfile use its default ARG BASE_IMAGE
-          echo "BASE_IMAGE=" | tee -a "$GITHUB_OUTPUT"
       - name: Build base Image
         uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
@@ -154,8 +124,6 @@ jobs:
           tags: ${{ needs.get-meta.outputs.ref_tag }}
           containerfiles: |
             containers/Containerfile
-          build-args: |
-            ${{ steps.base.outputs.BASE_IMAGE != '' && format('BASE_IMAGE={0}', steps.base.outputs.BASE_IMAGE) || '' }}
           oci: true
       - name: Inspect the created image
         run: 'podman inspect systemd-prepared:${{ needs.get-meta.outputs.ref_tag }}'

--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -1,6 +1,5 @@
 # https://github.com/kachick/containers
-ARG BASE_IMAGE=ghcr.io/kachick/ubuntu-24.04-nix-systemd:latest@sha256:353fd33f85bf98b458f8e43fbf174e960cad1594458f7308933d35b60e082f2a
-FROM ${BASE_IMAGE}
+FROM ghcr.io/kachick/ubuntu-24.04-nix-systemd:latest@sha256:353fd33f85bf98b458f8e43fbf174e960cad1594458f7308933d35b60e082f2a
 
 LABEL org.opencontainers.image.source=https://github.com/kachick/dotfiles
 LABEL org.opencontainers.image.description="Example by kachick/dotfiles"

--- a/containers/build.bash
+++ b/containers/build.bash
@@ -2,32 +2,8 @@
 
 set -euxo pipefail
 
-# Fallback to defaults if not set (e.g., local build)
-# The image name in GHCR
-readonly IMAGE_NAME="${IMAGE_NAME:-home}"
-# The base URL for GHCR
-readonly GHCR_BASE="${GHCR_BASE:-ghcr.io/kachick}"
-
-# The latest provisioned image used for incremental builds
-readonly PREV_IMAGE="${GHCR_BASE}/${IMAGE_NAME}:latest"
-
 build() {
-	local build_args=()
-
-	# Try to use the previous image as a base for incremental build unless forced to full rebuild
-	if [[ "${FORCE_FULL_REBUILD:-false}" != "true" ]]; then
-		if podman pull "${PREV_IMAGE}"; then
-			build_args=("--build-arg" "BASE_IMAGE=${PREV_IMAGE}")
-			echo "Using previous image as base for incremental build: ${PREV_IMAGE}"
-		else
-			echo "Previous image not found. Falling back to the default in Containerfile."
-		fi
-	else
-		echo "Forcing full rebuild using the default in Containerfile."
-	fi
-
 	podman build \
-		"${build_args[@]}" \
 		--tag nix-systemd \
 		--file containers/Containerfile .
 

--- a/containers/needs_systemd.bash
+++ b/containers/needs_systemd.bash
@@ -4,9 +4,5 @@ set -euxo pipefail
 
 git config --global --add safe.directory /provisioner/dotfiles
 nix run '/provisioner/dotfiles#home-manager' -- switch -b backup --flake '/provisioner/dotfiles/#user@container'
-
-# Do NOT run 'nix store gc' here.
-# 1. It makes builds slower by deleting packages that could be reused in the next incremental build.
-# 2. In a container layer structure, deleting files in a new layer does NOT reduce the total image size;
-#    it only adds a 'deletion' record while the original files remain in the base layer.
-# 3. Periodic full rebuilds (Squash) are a better way to clean up the store and reduce image size.
+# Also we can call gc without sudo!
+nix store gc


### PR DESCRIPTION
Reusing the previous image as a base made debugging difficult when
layers became inconsistent. This change reverts to performing a full
build from a clean base image every time.

Revert GH-1531 to debug old ubuntu version while testing GH-1611
