### PR TITLE
Replace gemini-cli with antigravity-cli

### DIFF
--- a/home-manager/linux.nix
+++ b/home-manager/linux.nix
@@ -74,8 +74,6 @@
         #
         # coredump can be output with `coredumpctl list` and `coredumpctl dump <ID> --output path`
         lldb
-
-        llm-agents.gemini-cli
       ])
       ++ (with pkgs.local; [
         rclone-list-mounted

--- a/home-manager/telemetry.nix
+++ b/home-manager/telemetry.nix
@@ -10,9 +10,6 @@
     sessionVariables = {
       # https://github.com/NixOS/nixpkgs/commit/a881767c939773a5f98eef7347d7ba9ba84eb531
       DO_NOT_TRACK = "1";
-
-      # https://github.com/google-gemini/gemini-cli/blob/8ac2c6842d222c6417f6de365878b66056656e48/docs/cli/telemetry.md?plain=1#L58
-      GEMINI_TELEMETRY_ENABLED = "false";
     };
 
     activation = {

--- a/nixos/desktop/unfree.nix
+++ b/nixos/desktop/unfree.nix
@@ -42,10 +42,13 @@
     # `rm -rf ~/.config/google-chrome/Singleton*`
     #
     google-chrome
+
+    llm-agents.antigravity-cli
   ];
 
   nixpkgs.allowedUnfreePackageNames = [
     "google-chrome"
     "vscode"
+    "antigravity-cli"
   ];
 }


### PR DESCRIPTION
Resolves GH-1583

Adding this only to NixOS for now because Home Manager is not ready for unfree packages yet.
So I cannot use antigravity-cli on WSL until setting up NixOS-WSL.